### PR TITLE
neo vimの設定ファイルを追加

### DIFF
--- a/CreateSymbolicLink.sh
+++ b/CreateSymbolicLink.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 ln -sf ~/conf_files/.vimrc ~/.vimrc
 ln -sf ~/conf_files/.tmux.conf ~/.tmux.conf
+ln -sf ~/conf_files/init.vim ~/.config/nvim/init.vim
+

--- a/init.vim
+++ b/init.vim
@@ -1,0 +1,23 @@
+set number
+set shell=/bin/zsh
+syntax on
+set tabstop=4
+set shiftwidth=4
+set expandtab
+set textwidth=0
+set autoindent
+set hlsearch
+set clipboard=unnamed
+
+" vim-plug
+call plug#begin()
+    Plug 'preservim/nerdtree' 
+
+call plug#end()
+
+"NERDTree
+nnoremap <C-n> :NERDTreeToggle<CR>
+" Start NERDTree when Vim is started without file arguments.
+autocmd StdinReadPre * let s:std_in=1
+autocmd VimEnter * if argc() == 0 && !exists('s:std_in') | NERDTree | endif
+


### PR DESCRIPTION
# 変更点
- neovim用設定ファイル `init.vim`を追加
-  `.config/neovim/`にシンボリックリンクを張るshを追記